### PR TITLE
Minor suggestions

### DIFF
--- a/src/tex/ms.tex
+++ b/src/tex/ms.tex
@@ -127,7 +127,7 @@ Furthermore, uptake of the approaches discussed herein will lead to greater clar
 % ARJN Application of a half-closed distribution may be as common? e.g. [0, inf] for a parameter that is known to be non-negative. Should we mention this in table 1?
 The most common probability distribution that is used for a prior is uniform between a lower and upper bound.
 The use of a bounded parameter along with some traditional $\chi^2$-minimisation method and a parameter with a uniform prior and a Bayesian maximum \emph{a-posteriori} approach will lead to the same result. 
-For priors that are uniform is it important that the upper and lower bounds are reported, this can be achieved with a simple table  (see Table~\ref{tab:bounds} for an example) to be included in the article or supplementary information. 
+For priors that are uniform it is important that the upper and lower bounds are reported. This can be achieved with a simple table  (see Table~\ref{tab:bounds} for an example) to be included in the article or supplementary information. 
 %
 \begin{table}
     \caption{An example of the presenting uniform priors in a tabular format. Reproduced from \cite{mccluskey_general_2020}, where each parameter was either constrained to a given value or sampled within the prior range.}
@@ -138,7 +138,7 @@ For priors that are uniform is it important that the upper and lower bounds are 
         $d_h$/\si{\angstrom} & $10.0$ & $[8.0, 16.0)$\\
         $V_h$/\si{\angstrom^3} & $339.5$ & $[300.0, 380.0)$\\
         $d_t$/\si{\angstrom} & $21.0$ & $[10.0, 26.0)$\\
-        $\phi_t$ & $1.0$ & $[0.5, 1.0)$\\
+        $\phi_t$ & $1.0$ & $[0.5, 1.0]$\\
         $V_t$/\si{\angstrom^3} & $850.4$ & $[800.0, 1000.0)$\\
         $\sigma$/\si{\angstrom} & $2.9$ & $[2.9, 5.0)$\\
     \end{tabular}


### PR DESCRIPTION
We probably also need to cite Zenodo? 

```
@misc{https://doi.org/10.25495/7gxk-rd71,
  doi = {10.25495/7GXK-RD71},
  url = {https://www.zenodo.org/},
  author = {{European Organization For Nuclear Research} and {OpenAIRE}},
  keywords = {FOS: Physical sciences, Publication, Dataset},
  language = {en},
  title = {Zenodo},
  publisher = {CERN},
  year = {2013}
}
```

I've been also thinking if it would make sense to present/summarize recomendations as a checklist or table. It may help when if someone wants to e.g. come back to paper and quickly check what are recomendations. It can also be included in supplementary information. 